### PR TITLE
Export existing resources from lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+mod error;
+mod rusty_tesseract;
+
+pub use error::*;
+pub use rusty_tesseract::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 mod rusty_tesseract;
-use rusty_tesseract::{Image, Args};
+use crate::rusty_tesseract::{Image, Args};
 use ndarray::Array3;
 use std::collections::HashMap;
 


### PR DESCRIPTION
I was able to build my trial program by adding a `path` dependency to my fork of `rusty-tesseract` and adding this `lib.rs` re-exporter.