### PR TITLE
Fixed issues when using rusty-tesseract from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-tesseract"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["thomasgruebl"]
 description = "A Rust wrapper for Google Tesseract"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # rusty-tesseract
+
 A Rust wrapper for Google Tesseract
 
 ![GitHub last commit](https://img.shields.io/github/last-commit/thomasgruebl/rusty-tesseract?style=plastic) ![GitHub](https://img.shields.io/github/license/thomasgruebl/rusty-tesseract?style=plastic) <a style="text-decoration: none" href="https://github.com/thomasgruebl/rusty-tesseract/stargazers">
@@ -13,23 +14,30 @@ A Rust wrapper for Google Tesseract
 </a>
 
 ## Installation
+
 Add the following line to your <b>Cargo.toml</b> file:
+
 ```rust
-rusty-tesseract = "1.0.0"
+rusty-tesseract = "1.0.1"
 ```
 
 ## Description
+
 - Brings all relevant command-line tesseract functionality to Rust
 - Based on the Python wrapper for tesseract (i.e. https://github.com/madmaze/pytesseract)
 - Enables testing a pre-trained tesseract model and outputting the results in different formats such as strings, bounding boxes, dicts, or dataframes.
 
 ## Dependencies
+
 Tesseract: https://github.com/tesseract-ocr/tesseract
 
 ## Usage
+
 ### 1. Read Image
+
 Create an Image object by specifying a path or alternatively an image array in (height, width, channel) format (similar to Python's numpy array for opencv).
 Note: Leave the Array3 parameter as is if you don't intend to use it.
+
 ```rust
 let mut img = Image::new(
     String::from("img/string.png"),
@@ -45,7 +53,9 @@ let mut img = Image {
 ```
 
 ### 2. Set tesseract parameters
-Set tesseract parameters using the Args struct. 
+
+Set tesseract parameters using the Args struct.
+
 ```rust
 let default_args = Args::new();
 
@@ -74,7 +84,9 @@ image_to_string_args.config.insert("oem", "3");  // define optical character rec
 ```
 
 ### 3. Get the tesseract model output
+
 Choose either string, bounding box or data output:
+
 ```rust
 // string output
 let output = rusty_tesseract::image_to_string(&img, my_args);
@@ -91,7 +103,7 @@ let mut image_to_boxes_args = Args {
 image_to_boxes_args.config.insert("psm", "6");
 image_to_boxes_args.config.insert("oem", "3");
 
-// boxes printed in OUTPUT_DICT or OUTPUT_DATAFRAME format store the key as a string (i.e. the character) and 
+// boxes printed in OUTPUT_DICT or OUTPUT_DATAFRAME format store the key as a string (i.e. the character) and
 // store the value as a list of strings (if the same character occurs more than once)
 let boxes = rusty_tesseract::image_to_boxes(&img, image_to_boxes_args);
 println!("The Boxfile output is: {:?}", boxes.Output_DATAFRAME);
@@ -102,6 +114,7 @@ println!("The data output is: {:?}", data.Output_DICT);
 ```
 
 ### Get tesseract version
+
 ```rust
 let tesseract_version = rusty_tesseract::get_tesseract_version();
 println!("The tesseract version is: {:?}", tesseract_version);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
-mod error;
-mod rusty_tesseract;
+pub mod error;
+pub mod tesseract;
 
 pub use error::*;
-pub use crate::rusty_tesseract::*;
+pub use tesseract::*;
+
+pub use ndarray;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,4 @@
-mod rusty_tesseract;
-use crate::rusty_tesseract::{Image, Args};
-use ndarray::Array3;
+use rusty_tesseract::{ndarray::Array3, Args, Image};
 use std::collections::HashMap;
 
 mod error;
@@ -9,25 +7,24 @@ mod error;
 
 // the main function provides usage samples of the rusty-tesseract wrapper
 fn main() {
-
     // create an Image object by specifying a path or alternatively an image array in (height, width, channel) format
     // if path is an empty string -> rusty-tesseract tries to use the ndarray
 
     // you can use the new function
-    let mut img = Image::new(
+    let _ = Image::new(
         String::from("img/string.png"),
-        Array3::<u8>::zeros((100, 100, 3))
+        Array3::<u8>::zeros((100, 100, 3)),
     );
 
     // or instantiate Image struct directly
-    let mut img = Image {
+    let img = Image {
         path: String::from("img/string.png"),
-        ndarray: Array3::<u8>::zeros((100, 100, 3))  // example: creates an 100x100 pixel image with 3 colour channels (RGB)
+        ndarray: Array3::<u8>::zeros((100, 100, 3)), // example: creates an 100x100 pixel image with 3 colour channels (RGB)
     };
 
     // use default_args to call a function if no particular config is needed
     let default_args = Args::new();
-    
+
     let tesseract_version = rusty_tesseract::get_tesseract_version();
     println!("The tesseract version is: {:?}", tesseract_version);
 
@@ -37,34 +34,32 @@ fn main() {
         lang: "eng",
         config: HashMap::new(),
         dpi: 150,
-        boxfile: false
+        boxfile: false,
     };
     image_to_string_args.config.insert("psm", "6");
     image_to_string_args.config.insert("oem", "3");
 
     let output = rusty_tesseract::image_to_string(&img, image_to_string_args);
-    println!("\nThe String output is: {:?}", output.Output_STRING);
+    println!("\nThe String output is: {:?}", output.output);
 
     let mut image_to_boxes_args = Args {
         out_filename: "font_name.font.exp0",
         lang: "eng",
         config: HashMap::new(),
         dpi: 150,
-        boxfile: true
+        boxfile: true,
     };
     image_to_boxes_args.config.insert("psm", "6");
     image_to_boxes_args.config.insert("oem", "3");
 
-    
-    // boxes printed in OUTPUT_DICT or OUTPUT_DATAFRAME format store the Key as a string (i.e. the character) and 
+    // boxes printed in OUTPUT_DICT or OUTPUT_DATAFRAME format store the Key as a string (i.e. the character) and
     // store the value as a list of strings (if the same character occurs more than once)
     let boxes = rusty_tesseract::image_to_boxes(&img, image_to_boxes_args);
-    println!("\nThe Boxfile output is: {:?}", boxes.Output_DATAFRAME);
-
+    println!("\nThe Boxfile output is: {:?}", boxes.dataframe);
 
     // image_to_data prints out both image_to_string and image_to_boxes information + a creates a TSV table with confidences
     let data = rusty_tesseract::image_to_data(&img, default_args);
-    println!("\nThe data output is: {:?}", data.Output_DICT);
+    println!("\nThe data output is: {:?}", data.dict);
     println!("\nThe confidence tesstable can be found in the [out_filename].tsv file!\n");
 }
 
@@ -74,9 +69,9 @@ mod tests {
 
     #[test]
     fn vertical_text() {
-        let mut img = Image::new(
+        let img = Image::new(
             String::from("img/vertical_text.png"),
-            Array3::<u8>::zeros((0, 0, 3))
+            Array3::<u8>::zeros((0, 0, 3)),
         );
 
         let mut image_to_string_args = Args {
@@ -84,66 +79,66 @@ mod tests {
             lang: "eng",
             config: HashMap::new(),
             dpi: 150,
-            boxfile: false
+            boxfile: false,
         };
 
         image_to_string_args.config.insert("psm", "6");
         image_to_string_args.config.insert("oem", "3");
-    
+
         let output_test = rusty_tesseract::image_to_string(&img, image_to_string_args);
-        assert_eq!(output_test.Output_STRING, "D\nO\nL\nO\nR\nS\nI\n\nT\n\u{c}");
+        assert_eq!(output_test.output, "D\nO\nL\nO\nR\nS\nI\n\nT\n");
     }
 
     #[test]
     fn horizontal_text() {
-        let mut img = Image::new(
+        let img = Image::new(
             String::from("img/horizontal_text.png"),
-            Array3::<u8>::zeros((0, 0, 3))
+            Array3::<u8>::zeros((0, 0, 3)),
         );
         let default_args = Args::new();
         let output_test = rusty_tesseract::image_to_string(&img, default_args);
-        assert_eq!(output_test.Output_STRING, "Lorem ipsum dolor sit amet\n\u{c}");
+        assert_eq!(output_test.output.trim(), "Lorem ipsum dolor sit amet");
     }
 
     #[test]
     fn image_to_data() {
-        let mut img = Image::new(
+        let img = Image::new(
             String::from("img/string.png"),
-            Array3::<u8>::zeros((0, 0, 3))
+            Array3::<u8>::zeros((0, 0, 3)),
         );
         let default_args = Args::new();
         let output_test = rusty_tesseract::image_to_data(&img, default_args);
-        assert_eq!(output_test.Output_STRING, "LOREM IPSUM DOLOR SIT AMET\n\u{c}");
+        assert_eq!(output_test.output.trim(), "LOREM IPSUM DOLOR SIT AMET");
     }
 
     #[test]
     fn image_to_string() {
-        let mut img = Image::new(
+        let img = Image::new(
             String::from("img/string.png"),
-            Array3::<u8>::zeros((0, 0, 3))
+            Array3::<u8>::zeros((0, 0, 3)),
         );
         let default_args = Args::new();
         let output_test = rusty_tesseract::image_to_string(&img, default_args);
-        assert_eq!(output_test.Output_STRING, "LOREM IPSUM DOLOR SIT AMET\n\u{c}");
+        assert_eq!(output_test.output.trim(), "LOREM IPSUM DOLOR SIT AMET");
     }
 
     #[test]
     fn image_to_boxes() {
-        let mut img = Image::new(
+        let img = Image::new(
             String::from("img/string.png"),
-            Array3::<u8>::zeros((0, 0, 3))
+            Array3::<u8>::zeros((0, 0, 3)),
         );
         let mut image_to_boxes_args = Args {
             out_filename: "eng.testcase.exp0",
             lang: "eng",
             config: HashMap::new(),
             dpi: 150,
-            boxfile: true
+            boxfile: true,
         };
         image_to_boxes_args.config.insert("psm", "6");
         image_to_boxes_args.config.insert("oem", "3");
 
         let boxes_test = rusty_tesseract::image_to_boxes(&img, image_to_boxes_args);
-        assert_eq!(boxes_test.Output_STRING, "L 18 26 36 59 0\nO 35 25 70 60 0\nR 75 26 98 59 0\nE 103 26 122 59 0\nM 127 26 162 59 0\nI 181 26 185 59 0\nP 191 26 214 59 0\nS 216 25 237 60 0\nU 240 25 263 59 0\nM 269 26 304 59 0\nD 323 26 352 59 0\nO 355 25 390 60 0\nL 360 25 415 60 0\nO 395 26 413 59 0\nR 413 25 476 60 0\nS 490 25 509 60 0\nI 490 25 518 60 0\nT 521 26 540 59 0\nA 553 26 586 59 0\nM 589 26 624 59 0\nE 603 26 649 59 0\nT 630 26 671 59 0\n");
+        assert_eq!(boxes_test.output.trim(), "L 18 26 36 59 0\nO 35 25 70 60 0\nR 75 26 98 59 0\nE 103 26 122 59 0\nM 127 26 162 59 0\nI 181 26 214 59 0\nP 203 25 226 60 0\nS 216 25 263 60 0\nU 252 25 280 60 0\nM 269 26 304 59 0\nD 323 26 352 59 0\nO 355 25 390 60 0\nL 395 26 413 59 0\nO 413 25 448 60 0\nR 453 26 476 59 0\nS 490 25 511 60 0\nI 514 26 518 59 0\nT 521 26 540 59 0\nA 553 26 586 59 0\nM 589 26 624 59 0\nE 630 26 649 59 0\nT 652 26 671 59 0");
     }
 }

--- a/src/tesseract.rs
+++ b/src/tesseract.rs
@@ -1,55 +1,36 @@
-use std::collections::HashMap;
-use multimap::MultiMap;
-use polars::prelude::*;
-use ndarray::Array3;
 use image::RgbImage;
+use multimap::MultiMap;
+use ndarray::Array3;
+use polars::prelude::*;
+use std::collections::HashMap;
+use std::env::current_dir;
 use std::fmt;
-use std::string::ToString;
+use std::fs;
 use std::io::BufRead;
 use std::process::{Command, Stdio};
-use std::fs;
-use std::env::current_dir;
+use std::string::ToString;
 
-use crate::error::VersionError;
-use crate::error::TesseractNotFoundError;
 use crate::error::ImageFormatError;
 use crate::error::ImageNotFoundError;
+use crate::error::TesseractNotFoundError;
+use crate::error::VersionError;
 
-const Formats: [&'static str; 10] = ["JPEG",
-                                    "JPG",
-                                    "PNG",
-                                    "PBM",
-                                    "PGM",
-                                    "PPM",
-                                    "TIFF",
-                                    "BMP",
-                                    "GIF",
-                                    "WEBP"];
+const FORMATS: [&'static str; 10] = [
+    "JPEG", "JPG", "PNG", "PBM", "PGM", "PPM", "TIFF", "BMP", "GIF", "WEBP",
+];
 
-
+#[derive(Default)]
 pub struct ModelOutput {
-    pub Output_INFO: String,
-    pub Output_BYTES: Vec<u8>,
-    pub Output_DICT: MultiMap<String, String>,
-    pub Output_STRING: String,
-    pub Output_DATAFRAME: Vec<Series>
-}
-
-impl ModelOutput {
-    fn new() -> ModelOutput {
-        ModelOutput {
-            Output_INFO: String::new(),
-            Output_BYTES: Vec::new(),
-            Output_DICT: MultiMap::new(),
-            Output_STRING: String::new(),
-            Output_DATAFRAME: Vec::new()
-        }
-    }
+    pub info: String,
+    pub bytes: Vec<u8>,
+    pub dict: MultiMap<String, String>,
+    pub output: String,
+    pub dataframe: Vec<Series>,
 }
 
 impl fmt::Display for ModelOutput {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.Output_STRING)
+        write!(f, "{}", self.output)
     }
 }
 
@@ -59,7 +40,7 @@ pub struct Args {
     pub lang: &'static str,
     pub config: HashMap<&'static str, &'static str>,
     pub dpi: i32,
-    pub boxfile: bool
+    pub boxfile: bool,
 }
 
 impl Args {
@@ -69,7 +50,7 @@ impl Args {
             lang: "eng",
             out_filename: "out",
             dpi: 150,
-            boxfile: false
+            boxfile: false,
         }
     }
 }
@@ -77,7 +58,7 @@ impl Args {
 #[derive(Clone)]
 pub struct Image {
     pub path: String,
-    pub ndarray: Array3<u8>
+    pub ndarray: Array3<u8>,
 }
 
 impl fmt::Display for Image {
@@ -88,10 +69,7 @@ impl fmt::Display for Image {
 
 impl Image {
     pub fn new(path: String, ndarray: Array3<u8>) -> Image {
-        Image {
-            path,
-            ndarray
-        }
+        Image { path, ndarray }
     }
 
     fn is_empty_ndarray(&self) -> bool {
@@ -103,7 +81,7 @@ impl Image {
     }
 
     fn size_of_ndarray(&self) -> (usize, usize, usize) {
-        return self.ndarray.dim()
+        return self.ndarray.dim();
     }
 
     fn ndarray_to_image(self) -> RgbImage {
@@ -120,7 +98,7 @@ fn type_of<T>(_: &T) -> String {
     return t;
 }
 
-fn read_output_file(filename: &String) -> String{
+fn read_output_file(filename: &String) -> String {
     let f = fs::read_to_string(filename.to_owned())
         .expect("File reading error. Filename does not exist.");
 
@@ -135,55 +113,42 @@ fn check_image_format(img: &Image) -> bool {
     let uppercase_format = tmp.as_str();
     let format = tmp2.as_str();
 
-    if Formats.contains(&format) || Formats.contains(&uppercase_format) {
+    if FORMATS.contains(&format) || FORMATS.contains(&uppercase_format) {
         return true;
-    }
-    else {
+    } else {
         return false;
     }
 }
 
 fn check_if_installed() -> bool {
-    if cfg!(target_os = "windows") {
-        match Command::new("tesseract.exe")
-                .stdout(Stdio::null())
-                .spawn() {
-                    Ok(_) => return true,
-                    Err(e) => return false, 
-        }
+    get_tesseract_command()
+        .stdout(Stdio::null())
+        .spawn()
+        .is_ok()
+}
+
+fn get_tesseract_command() -> Command {
+    let tesseract = if cfg!(target_os = "windows") {
+        "tesseract.exe"
     } else {
-        match Command::new("tesseract")
-                .stdout(Stdio::null())
-                .spawn() {
-                    Ok(_) => return true,
-                    Err(_e) => return false, 
-        }
-    }
+        "tesseract"
+    };
+
+    Command::new(tesseract)
 }
 
 pub fn get_tesseract_version() -> String {
-
     let is_installed: bool = check_if_installed();
     if !is_installed {
         panic!("{}", TesseractNotFoundError);
     }
 
-    let command = if cfg!(target_os = "windows") {
-        Command::new("tesseract.exe")
-            .arg("--version")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap()
-                
-    } else {
-        Command::new("tesseract")
-            .arg("--version")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap()
-    };
+    let command = get_tesseract_command()
+        .arg("--version")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
 
     let output = command.wait_with_output().unwrap();
 
@@ -193,19 +158,16 @@ pub fn get_tesseract_version() -> String {
 
     match status.code() {
         Some(code) => println!("Exited with status code: {}", code),
-        None       => println!("Exited with error: {}", VersionError)
+        None => println!("Exited with error: {}", VersionError),
     }
 
     let mut str_res = String::new();
     if out.len() == 0 {
-        err.lines().for_each(|line|
-            str_res = format!("{}\n{}", str_res, line.unwrap())
-        );
-    }
-    else {
-        out.lines().for_each(|line|
-            str_res = format!("{}\n{}", str_res, line.unwrap())
-        );
+        err.lines()
+            .for_each(|line| str_res = format!("{}\n{}", str_res, line.unwrap()));
+    } else {
+        out.lines()
+            .for_each(|line| str_res = format!("{}\n{}", str_res, line.unwrap()));
     }
 
     return str_res;
@@ -219,11 +181,11 @@ pub fn image_to_data(image: &Image, args: Args) -> ModelOutput {
     let box_out: ModelOutput = image_to_boxes(&image, box_args);
 
     let out = ModelOutput {
-        Output_INFO: str_out.Output_INFO,
-        Output_BYTES: str_out.Output_BYTES,
-        Output_DICT: box_out.Output_DICT,
-        Output_STRING: str_out.Output_STRING,
-        Output_DATAFRAME: box_out.Output_DATAFRAME
+        info: str_out.info,
+        bytes: str_out.bytes,
+        dict: box_out.dict,
+        output: str_out.output,
+        dataframe: box_out.dataframe,
     };
 
     let mut tesstable_args = args.clone();
@@ -232,8 +194,7 @@ pub fn image_to_data(image: &Image, args: Args) -> ModelOutput {
 
     if check_image_format(&image) {
         return out;
-    }
-    else {
+    } else {
         panic!("{}", ImageFormatError);
     }
 }
@@ -247,7 +208,6 @@ pub fn image_to_string(image: &Image, args: Args) -> ModelOutput {
 }
 
 fn run_tesseract(image: &Image, args: &Args) -> ModelOutput {
-
     // check if tesseract is installed
     let is_installed: bool = check_if_installed();
     if !is_installed {
@@ -255,7 +215,10 @@ fn run_tesseract(image: &Image, args: &Args) -> ModelOutput {
     }
 
     assert_eq!(type_of(&image.path), type_of(&String::new()));
-    assert_eq!(type_of(&image.ndarray), type_of(&Array3::<u8>::zeros((0, 0, 0))));
+    assert_eq!(
+        type_of(&image.ndarray),
+        type_of(&Array3::<u8>::zeros((0, 0, 0)))
+    );
 
     // check if image path or ndarray is provided
     let mut image_arg = String::from("");
@@ -266,12 +229,12 @@ fn run_tesseract(image: &Image, args: &Args) -> ModelOutput {
         let i = tmp_img.ndarray_to_image();
         let working_dir = current_dir().unwrap().as_path().display().to_string();
         let new_path = [working_dir, String::from("ndarray_converted.png")].join("/");
-        
+
         match i.save(&new_path) {
             Ok(_r) => {
                 println!("Image saved: {:?}", new_path);
                 image_arg = new_path;
-            }, 
+            }
             Err(e) => println!("Error while saving image: {:?}", e),
         }
     }
@@ -310,52 +273,30 @@ fn run_tesseract(image: &Image, args: &Args) -> ModelOutput {
         psm = args.config["psm"];
     }
 
-    if args.config.contains_key("oem"){
+    if args.config.contains_key("oem") {
         oem = args.config["oem"];
     }
 
     println!("the image arg is: {:?}", image_arg);
 
-    let command = if cfg!(target_os = "windows") {
-        Command::new("tesseract.exe")
-            .arg(image_arg)
-            .arg(args.out_filename)
-            .arg("-l")
-            .arg(args.lang)
-            .arg("--dpi")
-            .arg(args.dpi.to_string())
-            .arg("--psm")
-            .arg(psm)
-            .arg("--oem")
-            .arg(oem)
-            .arg("-c")
-            .arg(tesstable_arg)
-            .arg(boxarg)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap()
-    } 
-    else {
-        Command::new("tesseract")
-            .arg(image_arg)
-            .arg(args.out_filename)
-            .arg("-l")
-            .arg(args.lang)
-            .arg("--dpi")
-            .arg(args.dpi.to_string())
-            .arg("--psm")
-            .arg(psm)
-            .arg("--oem")
-            .arg(oem)
-            .arg("-c")
-            .arg(tesstable_arg)
-            .arg(boxarg)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap()
-    };
+    let command = get_tesseract_command()
+        .arg(image_arg)
+        .arg(args.out_filename)
+        .arg("-l")
+        .arg(args.lang)
+        .arg("--dpi")
+        .arg(args.dpi.to_string())
+        .arg("--psm")
+        .arg(psm)
+        .arg("--oem")
+        .arg(oem)
+        .arg("-c")
+        .arg(tesstable_arg)
+        .arg(boxarg)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
 
     let output = command.wait_with_output().unwrap();
     println!("{:?}", output);
@@ -366,37 +307,28 @@ fn run_tesseract(image: &Image, args: &Args) -> ModelOutput {
 
     match status.code() {
         Some(code) => println!("Exited with status code: {}", code),
-        None       => println!("Process terminated by signal")
+        None => println!("Process terminated by signal"),
     }
 
     let mut str_res = String::new();
-    if out.len() == 0 {
-        err.lines().for_each(|line|
-            str_res = format!("{}\n{}", str_res, line.unwrap())
-        );
-    }
-    else {
-        out.lines().for_each(|line|
-            str_res = format!("{}\n{}", str_res, line.unwrap())
-        );
-    }
+    if out.len() == 0 { err } else { out }
+        .lines()
+        .for_each(|line| str_res = format!("{}\n{}", str_res, line.unwrap()));
 
     // read tesseract output from output file "out.txt"
-    let mut out_f = String::new();
+    let out_f;
     if !args.boxfile {
         if !args.out_filename.contains(".txt") {
-            out_f = format!("{}.txt", args.out_filename); 
-        }
-        else {
+            out_f = format!("{}.txt", args.out_filename);
+        } else {
             out_f = args.out_filename.to_string();
         }
     }
     // if boxfile is requested -> read from .box file
     else {
         if !args.out_filename.contains(".box") {
-            out_f = format!("{}.box", args.out_filename); 
-        }
-        else {
+            out_f = format!("{}.box", args.out_filename);
+        } else {
             out_f = args.out_filename.to_string();
         }
     }
@@ -411,10 +343,7 @@ fn run_tesseract(image: &Image, args: &Args) -> ModelOutput {
             if line.contains(" ") {
                 // fill dict
                 let tuple = line.split_once(" ").unwrap();
-                dict.insert(
-                    String::from(tuple.0),
-                    String::from(tuple.1),
-                );
+                dict.insert(String::from(tuple.0), String::from(tuple.1));
 
                 // fill DataFrame (Vec of Series)
                 let character: &str = &tuple.0;
@@ -428,13 +357,13 @@ fn run_tesseract(image: &Image, args: &Args) -> ModelOutput {
             }
         }
     }
-    
+
     let out = ModelOutput {
-        Output_INFO: str_res,
-        Output_BYTES: file_output.as_bytes().to_vec(),
-        Output_DICT: dict,
-        Output_STRING: file_output,
-        Output_DATAFRAME: df
+        info: str_res,
+        bytes: file_output.as_bytes().to_vec(),
+        dict,
+        output: file_output,
+        dataframe: df,
     };
 
     return out;


### PR DESCRIPTION
I tried to use this crate from crates.io in one of my project but i got a "unresolved import `rusty_tesseract`" error:
![rusty_tesseract_unresolved](https://user-images.githubusercontent.com/1730903/226207929-78f4fd11-f8e7-4766-bb56-eb3ef187b62f.PNG)

In this PR i changed the name of the modul "rusty_tesseract" to "tesseract" to avoid name conflicts with the name of the project root.  I added a re-export for "ndarray" and made the moduls "error" and "tesseract" public.  I also fixed some warnings from the rust-compiler.
