### PR TITLE
hide command console on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-tesseract"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 authors = ["thomasgruebl"]
 description = "A Rust wrapper for Google Tesseract"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A Rust wrapper for Google Tesseract
 Add the following line to your <b>Cargo.toml</b> file:
 
 ```rust
-rusty-tesseract = "1.1.1"
+rusty-tesseract = "1.1.2"
 ```
 
 ## Description

--- a/src/tesseract/command.rs
+++ b/src/tesseract/command.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::os::windows::process::CommandExt;
 use std::process::{Command, Stdio};
 use std::string::ToString;
 
@@ -21,9 +22,15 @@ pub fn get_tesseract_version() -> TessResult<String> {
     run_tesseract_command(&mut command)
 }
 
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
 pub(crate) fn run_tesseract_command(command: &mut Command) -> TessResult<String> {
     if cfg!(debug_assertions) {
         show_command(command);
+    }
+
+    if cfg!(windows) {
+        command.creation_flags(CREATE_NO_WINDOW);
     }
 
     let child = command


### PR DESCRIPTION
Fixes a problem where the command opens a console in release mode on windows.