### PR TITLE
Updated the version of the image library from 0.23.14 to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ repository = "https://github.com/thomasgruebl/rusty-tesseract"
 [dependencies]
 subprocess = "0.2.8"
 substring = "1.4.5"
-image = "0.23.14"
+image = "0.24"
 thiserror = "1.0.40"
 tempfile = "3.4.0"


### PR DESCRIPTION
Updated the version of the image library from 0.23.14 to 0.24 to resolve type mismatch

Previously, using the latest version of the image library (0.24) resulted in a type mismatch error when interfacing with rusty_tesseract, which uses version 0.23.14 of the image library. This update resolves that issue by aligning the version of the image library used in the main code with the version used by rusty_tesseract.

```rust
fn main() {
	// image version is 0.24
	let dynamic_image = image::io::Reader::open("img/string.png")
		.unwrap()
		.decode()
		.unwrap();

	// rusty_tesseract image version is 0.23.14
	let img = rusty_tesseract::tesseract::input::Image::from_dynamic_image(&dynamic_image).unwrap(); // Error
}
```

> error[E0308]: mismatched types
>   --> src\main.rs:9:76
>    |
> 7  |     let img = rusty_tesseract::tesseract::input::Image::from_dynamic_image(&dynamic_image).unwrap();
>    |               ------------------------------------------------------------ ^^^^^^^^^^^^^^ expected `rusty_tesseract::image::DynamicImage`, found `image::DynamicImage`
>    |               |
>    |               arguments to this function are incorrect

This update ensures that our usage of the image library is compatible with rusty_tesseract, eliminating the type mismatch error.