### PR TITLE
Changed dpi, psm and oem to Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,14 @@ let default_args = Args::default();
 /*
 Args {
     lang: "eng",
-    dpi: 150,
-    psm: 3,
-    oem: 3,
+    dpi: Some(150),
+    psm: Some(3),
+    oem: Some(3),
 }
 */
 
 // fill your own argument struct if needed
+// Optional arguments are ignored if set to `None`
 let mut my_args = Args {
     //model language (tesseract default = 'eng')
     //available languages can be found by running 'rusty_tesseract::get_tesseract_langs()'
@@ -80,9 +81,9 @@ let mut my_args = Args {
             "tessedit_char_whitelist".into(),
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".into(),
         )]),
-    dpi: 150,       // specify DPI for input image
-    psm: 3,         // define page segmentation mode 6 (i.e. "Assume a single uniform block of text")
-    oem: 3,         // define optical character recognition mode 3 (i.e. "Default, based on what is available")
+    dpi: Some(150),       // specify DPI for input image
+    psm: Some(6),         // define page segmentation mode 6 (i.e. "Assume a single uniform block of text")
+    oem: Some(3),         // define optical character recognition mode 3 (i.e. "Default, based on what is available")
 };
 ```
 
@@ -98,9 +99,9 @@ let mut my_args = Args {
             "tessedit_char_whitelist".into(),
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".into(),
         )]),
-    dpi: 150,
-    psm: 6,
-    oem: 3
+    dpi: Some(150),
+    psm: Some(6),
+    oem: Some(3)
 };
 
 // string output

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,9 +34,9 @@ fn main() {
             "tessedit_char_whitelist".into(),
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".into(),
         )]),
-        dpi: 150,
-        psm: 6,
-        oem: 3,
+        dpi: Some(150),
+        psm: Some(6),
+        oem: Some(3),
     };
 
     //you can get the list of available config variables with:
@@ -76,7 +76,7 @@ mod tests {
         let img = Image::from_path("img/vertical_text.png").unwrap();
 
         let image_to_string_args = Args {
-            psm: 6,
+            psm: Some(6),
             ..Default::default()
         };
 
@@ -100,6 +100,34 @@ mod tests {
         let img = Image::from_path("img/string.png").unwrap();
         let default_args = Args::default();
         let output = rusty_tesseract::image_to_string(&img, &default_args).unwrap();
+        assert_eq!(output.trim(), "LOREM IPSUM DOLOR SIT AMET");
+    }
+
+    #[test]
+    fn command_without_options() {
+        let img = Image::from_path("img/string.png").unwrap();
+        let args = Args {
+            dpi: None,
+            psm: None,
+            oem: None,
+            ..Args::default()
+        };
+
+        let output = rusty_tesseract::image_to_string(&img, &args).unwrap();
+        assert_eq!(output.trim(), "LOREM IPSUM DOLOR SIT AMET");
+    }
+
+    #[test]
+    fn command_with_partial_options() {
+        let img = Image::from_path("img/string.png").unwrap();
+        let args = Args {
+            dpi: Some(300),
+            psm: None,
+            oem: None,
+            ..Args::default()
+        };
+
+        let output = rusty_tesseract::image_to_string(&img, &args).unwrap();
         assert_eq!(output.trim(), "LOREM IPSUM DOLOR SIT AMET");
     }
 }

--- a/src/tesseract/command.rs
+++ b/src/tesseract/command.rs
@@ -57,7 +57,7 @@ pub(crate) fn run_tesseract_command(command: &mut Command) -> TessResult<String>
     let out = String::from_utf8(output.stdout).unwrap();
     let err = String::from_utf8(output.stderr).unwrap();
     let status = output.status;
-   
+
     match status.code() {
         Some(0) => Ok(out),
         _ => Err(TessError::CommandExitStatusError(status.to_string(), err)),
@@ -91,13 +91,19 @@ pub(crate) fn create_tesseract_command(image: &Image, args: &Args) -> TessResult
         .arg(image.get_image_path()?)
         .arg("stdout")
         .arg("-l")
-        .arg(args.lang.clone())
-        .arg("--dpi")
-        .arg(args.dpi.to_string())
-        .arg("--psm")
-        .arg(args.psm.to_string())
-        .arg("--oem")
-        .arg(args.oem.to_string());
+        .arg(args.lang.clone());
+
+    if let Some(dpi) = args.dpi {
+        command.arg("--dpi").arg(dpi.to_string());
+    }
+
+    if let Some(psm) = args.psm {
+        command.arg("--psm").arg(psm.to_string());
+    }
+
+    if let Some(oem) = args.oem {
+        command.arg("--oem").arg(oem.to_string());
+    }
 
     if let Some(parameter) = args.get_config_variable_args() {
         command.arg("-c").arg(parameter);

--- a/src/tesseract/input.rs
+++ b/src/tesseract/input.rs
@@ -11,9 +11,9 @@ use crate::{TessError, TessResult};
 pub struct Args {
     pub lang: String,
     pub config_variables: HashMap<String, String>,
-    pub dpi: i32,
-    pub psm: i32,
-    pub oem: i32,
+    pub dpi: Option<i32>,
+    pub psm: Option<i32>,
+    pub oem: Option<i32>,
 }
 
 impl Default for Args {
@@ -21,9 +21,9 @@ impl Default for Args {
         Args {
             lang: "eng".into(),
             config_variables: HashMap::new(),
-            dpi: 150,
-            psm: 3,
-            oem: 3,
+            dpi: Some(150),
+            psm: Some(3),
+            oem: Some(3),
         }
     }
 }

--- a/src/tesseract/output_boxes.rs
+++ b/src/tesseract/output_boxes.rs
@@ -89,7 +89,7 @@ mod tests {
     fn test_image_to_boxes() {
         let img = Image::from_path("img/string.png").unwrap();
         let mut image_to_boxes_args = Args::default();
-        image_to_boxes_args.psm = 6;
+        image_to_boxes_args.psm = Some(6);
 
         let result = image_to_boxes(&img, &image_to_boxes_args).unwrap();
         assert_eq!(

--- a/src/tesseract/output_data.rs
+++ b/src/tesseract/output_data.rs
@@ -121,7 +121,7 @@ mod tests {
     fn test_image_to_data() {
         let img = Image::from_path("img/string.png").unwrap();
         let mut image_to_boxes_args = Args::default();
-        image_to_boxes_args.psm = 6;
+        image_to_boxes_args.psm = Some(6);
 
         let result = tesseract::image_to_data(&img, &image_to_boxes_args).unwrap();
         assert_eq!(


### PR DESCRIPTION
I currently have a use case that the `dpi` argument should not be set. 

This PR changed `dpi`, `psm` and `oem` from `i32` to `Option<i32>`.