### PR TITLE
Use `-c` flag before each of configuration variables passed to tesseract

### DIFF
--- a/src/tesseract/command.rs
+++ b/src/tesseract/command.rs
@@ -105,7 +105,7 @@ pub(crate) fn create_tesseract_command(image: &Image, args: &Args) -> TessResult
         command.arg("--oem").arg(oem.to_string());
     }
 
-    if let Some(parameter) = args.get_config_variable_args() {
+    for parameter in args.get_config_variable_args() {
         command.arg("-c").arg(parameter);
     }
 

--- a/src/tesseract/input.rs
+++ b/src/tesseract/input.rs
@@ -29,17 +29,11 @@ impl Default for Args {
 }
 
 impl Args {
-    pub(crate) fn get_config_variable_args(&self) -> Option<String> {
-        if self.config_variables.is_empty() {
-            return None;
-        }
-        Some(
-            self.config_variables
-                .iter()
-                .map(|(key, value)| format!("{}={}", key, value))
-                .collect::<Vec<_>>()
-                .join(" "),
-        )
+    pub(crate) fn get_config_variable_args(&self) -> Vec<String> {
+        self.config_variables
+            .iter()
+            .map(|(key, value)| format!("{}={}", key, value))
+            .collect::<Vec<_>>()
     }
 }
 


### PR DESCRIPTION
When more than one configuration variable is specified, like in the example from https://github.com/thomasgruebl/rusty-tesseract/issues/13#issuecomment-1684948526
`-c` flag is passed just once before both configuration variables. Like this:
```
tesseract x.png stdout -l eng --dpi 150 --psm 3 --oem 3 -c tessedit_create_hocr=1 tessedit_char_whitelist=abc
```
or like this
```
tesseract x.png stdout -l eng --dpi 150 --psm 3 --oem 3 -c tessedit_char_whitelist=abc tessedit_create_hocr=1 
```
And in such case tesseract applies only the first key-value pair and seem to ignore the rest (views `key1=value1 key2=value2` as a single `key1=longer_value` pair).

According to tesseract CLI man page `-c` flag has to be specified before each of `configvar=value` pair.
Something like this:
```
tesseract x.png stdout -l eng --dpi 150 --psm 3 --oem 3 -c tessedit_char_whitelist=abc -c tessedit_create_hocr=1 
```

Please take a look into the proposed fix.